### PR TITLE
Fix 'TypeError: Cannot read property 'lang' of undefined

### DIFF
--- a/src/component/QDecimal.js
+++ b/src/component/QDecimal.js
@@ -67,7 +67,7 @@ export default function ({ ssrContext }) {
     },
     computed: {
       language () {
-        return (this.lang || Quasar.lang.isoName || navigator.language) + '-u-nu-latn'
+        return (this.lang || this.$q.lang.isoName || navigator.language) + '-u-nu-latn'
       },
       intl () {
         return {


### PR DESCRIPTION
I've fixed 'TypeError: Cannot read property 'lang' of undefined at a.language (QDecimal.js:70)'. 

Quasar.lang is undefined. I've changed it to this.$q.lang.isoName as in app-extension-qdatetimepicker. Error has gone.